### PR TITLE
Workaround to prevent transport: http2Server.HandleStreams failed to …

### DIFF
--- a/main.go
+++ b/main.go
@@ -275,7 +275,12 @@ func main() {
 		return
 	}
 	connDuration := time.Since(connStart)
-	defer conn.Close()
+	defer func() {
+		// Workaround to prevent transport: http2Server.HandleStreams failed to read frame issue
+		// https://github.com/grpc-ecosystem/grpc-health-probe/issues/34
+		time.Sleep(time.Millisecond)
+		conn.Close()
+	}()
 	if flVerbose {
 		log.Printf("connection established (took %v)", connDuration)
 	}


### PR DESCRIPTION
…read frame issue

@bmon @awilmore 

This is the second part of the noisy logs for health checks, what are your thoughts on this, supposedly this works, and I have verified it locally, this is a fork of the original health check cmd that we build and use and I have applied only a small change.

This should prevent the lines:

```
[transport] transport: http2Server.HandleStreams failed to read frame: read tcp 127.0.0.1:8080->127.0.0.1:34024: read: connection reset by peer
```

the alternative is to do the same thing for this line with sumo, but I think this one would be fairly critical if it happens outside of health checks right?

let me know on your thoughts